### PR TITLE
Remove exposed port

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -42,6 +42,4 @@ RUN ldconfig
 
 WORKDIR /op25/op25/gr-op25_repeater/apps
 
-EXPOSE 8080
-
 CMD ["sh", "config/op25.sh"]


### PR DESCRIPTION
This removes the EXPOSE 8080 from Dockerfile as it is redundant.